### PR TITLE
change PWP::Encoding to PWP::SingleEncoding

### DIFF
--- a/lib/Pod/Weaver/PluginBundle/Author/RWSTAUNER.pm
+++ b/lib/Pod/Weaver/PluginBundle/Author/RWSTAUNER.pm
@@ -28,7 +28,7 @@ sub mvp_bundle_config {
 
   push @plugins, (
     # plugin
-    _plain('-Encoding'),
+    _plain('-SingleEncoding'),
     _plain('-WikiDoc'),
     # default
     _plain('@CorePrep'),


### PR DESCRIPTION
Hi,

`Pod::Weaver` now has`SingleEncoding` plugin (starting from 4.000), which makes `Pod::Weaver::Plugin::Encoding` an extra dependency that could be thrown away.

See [Rik's post](http://rjbs.manxome.org/rubric/entry/2021) and also check out my quest for details/comments:

> http://questhub.io/realm/perl/quest/5277f3cc9f567ad56f0000e7

Cheers,
Sergey
