### PR TITLE
[ContributorsFromGit] -> [Git::Contributors]

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/Author/RWSTAUNER.pm
+++ b/lib/Dist/Zilla/PluginBundle/Author/RWSTAUNER.pm
@@ -319,7 +319,7 @@ sub configure {
       }
     ],
     [ GithubMeta => { ':version' => '0.10' } ],
-    [ ContributorsFromGit => { ':version' => '0.005' } ],
+    [ 'Git::Contributors' ],
   ) if $self->open_source;
 
   $self->add_plugins('AutoPrereqs')


### PR DESCRIPTION
The latter has fewer prerequisites and does not have issues on MSWin32.
